### PR TITLE
fix: remove fallback on steering axis

### DIFF
--- a/src/modules/parser/utils/parseOverlayConfig.ts
+++ b/src/modules/parser/utils/parseOverlayConfig.ts
@@ -1,5 +1,5 @@
 import { ParsedUrlQuery } from 'querystring'
-import { DEFAULT_ACCELERATE_BUTTON, DEFAULT_BRAKE_BUTTON, DEFAULT_STEERING_AXIS, DEFAULT_STEERING_DEADZONE } from '~/types/constants'
+import { DEFAULT_ACCELERATE_BUTTON, DEFAULT_BRAKE_BUTTON, DEFAULT_STEERING_DEADZONE } from '~/types/constants'
 import { TrackmaniaOverlayConfig } from '~/types/overlay'
 
 export default function parseOverlayConfig(
@@ -10,7 +10,7 @@ export default function parseOverlayConfig(
     return {
       accelerateButton: (config?.accelerateButton as string) || `${DEFAULT_ACCELERATE_BUTTON}`,
       brakeButton: (config?.brakeButton as string) || `${DEFAULT_BRAKE_BUTTON}`,
-      steeringAxis: (config?.steeringAxis as string) || `${DEFAULT_STEERING_AXIS}`,
+      steeringAxis: config?.steeringAxis as string,
       accelerateAxis: config?.accelerateAxis as string,
       steeringLeftButton: config?.steeringLeftButton as string,
       steeringRightButton: config?.steeringRightButton as string,
@@ -22,7 +22,7 @@ export default function parseOverlayConfig(
   return {
     accelerateButton: (config?.accelerateButton as string) || `${DEFAULT_ACCELERATE_BUTTON}`,
     brakeButton: (config?.brakeButton as string) || `${DEFAULT_BRAKE_BUTTON}`,
-    steeringAxis: (config?.steeringAxis as string) || `${DEFAULT_STEERING_AXIS}`,
+    steeringAxis: config?.steeringAxis as string,
     steeringDeadzone: (config?.steeringDeadzone as string) || `${DEFAULT_STEERING_DEADZONE}`,
     controllerIndex: (config?.controllerIndex as string) || '0'
   }


### PR DESCRIPTION
When steering axis is not set, the overlay shouldn't fallback to axis 0.

Fixes #31.